### PR TITLE
fix condition order for failed logins

### DIFF
--- a/INWX/Domrobot.py
+++ b/INWX/Domrobot.py
@@ -70,7 +70,7 @@ class ApiClient:
         }
 
         login_result = self.call_api('account.login', params)
-        if 'tfa' in login_result['resData'] and login_result['resData']['tfa'] != '0' and login_result['code'] == 1000:
+        if login_result['code'] == 1000 and 'tfa' in login_result['resData'] and login_result['resData']['tfa'] != '0':
             if shared_secret is None:
                 raise Exception('Api requests two factor challenge but no shared secret is given. Aborting.')
             secret_code = self.get_secret_code(shared_secret)


### PR DESCRIPTION
just doing a simple switcheroo on the condition chain. If a login fails, then there is no `resData` so an exception happens on that spot.

By first checking for code = 1000 we can "assume" that resData is set.