### PR TITLE
ensure UTF-8 communication in call_api

### DIFF
--- a/INWX/Domrobot.py
+++ b/INWX/Domrobot.py
@@ -121,11 +121,11 @@ class ApiClient:
             raise Exception('Invalid ApiType.')
 
         headers = {
-            'Content-Type': 'text/xml',
+            'Content-Type': 'text/xml; charset=UTF-8',
             'User-Agent': 'DomRobot/' + ApiClient.CLIENT_VERSION + ' (Python ' + self.get_python_version() + ')'
         }
 
-        response = self.api_session.post(self.api_url + self.api_type.value, data=payload, headers=headers)
+        response = self.api_session.post(self.api_url + self.api_type.value, data=payload.encode('UTF-8'), headers=headers)
 
         if self.debug_mode:
             print('Request (' + api_method + '): ' + payload)


### PR DESCRIPTION
With your provided domaincheck.py example I checked "my-test-domain-which-is-definitely-not-registered6737.移动" which resulted in
```
Traceback (most recent call last):
  File "domaincheck.py", line 22, in <module>
    domain_check_result = api_client.call_api(api_method='domain.check', method_params={'domain': domain})
  File "/home/txt/.local/lib/python3.7/site-packages/INWX/Domrobot.py", line 128, in call_api
    response = self.api_session.post(self.api_url + self.api_type.value, data=payload, headers=headers)
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 581, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python3/dist-packages/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 354, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib/python3.7/http/client.py", line 1229, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3.7/http/client.py", line 1274, in _send_request
    body = _encode(body, 'body')
  File "/usr/lib/python3.7/http/client.py", line 160, in _encode
    (name.title(), data[err.start:err.end], name)) from None
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 213-214: Body ('移动') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.
```

With the change I get a correct answer.

The change for the content-type was not needed as UTF-8 is the standard encoding nowadays. But I think it's better to state it explicitly cause the request will be using UTF-8.