### PR TITLE
raise an exception if the http request failed

### DIFF
--- a/INWX/Domrobot.py
+++ b/INWX/Domrobot.py
@@ -128,6 +128,7 @@ class ApiClient:
 
         response = self.api_session.post(self.api_url + self.api_type.value, data=payload.encode('UTF-8'),
                                          headers=headers)
+        response.raise_for_status()
 
         if self.debug_mode:
             print('Request (' + api_method + '): ' + payload)


### PR DESCRIPTION
Right now the code expects that the http request worked and doesn't even check the that http status code returned by the server. If for example the API returns a error 500 message or any other error, the client doesn't catch that error but just tries to parse the body of the response as json or as an XMLrpc response, which fails. In that case you just get a `JSONDecodeError`, `xml.parsers.expat.ExpatError` or similar exception without knowing that the actual cause for that exception was the non successful http request.